### PR TITLE
fixes: Cannot read property '$locale' of undefined

### DIFF
--- a/src/relative.js
+++ b/src/relative.js
@@ -26,7 +26,7 @@ export default function (date, options) {
         return formatDate(date);
     }
 
-    return format((date - new Date()) / 1000, options, this.$locale.TIMESPAN_FORMATS);
+    return format.apply(this, [(date - new Date()) / 1000, options, this.$locale.TIMESPAN_FORMATS]);
 }
 
 function calculate_unit(seconds, unit_options) {


### PR DESCRIPTION
This fixes the scope of the format function by forwarding the current scope of itself.